### PR TITLE
full load yaml

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -34,7 +34,7 @@ def relative_kp(kp_source, kp_driving, kp_driving_initial):
 
 def load_checkpoints(config_path, checkpoint_path, device):
     with open(config_path) as f:
-        config = yaml.load(f)
+        config = yaml.full_load(f)
 
     inpainting = InpaintingNetwork(**config['model_params']['generator_params'],
                                         **config['model_params']['common_params'])


### PR DESCRIPTION
I kept getting the error:

`positional argument Loader missing from line 37 demo.py`. It seems that on versions >= 5 of pyaml that is additonal argument is required or `yaml.load` should be set to either `safe_load` or full_load. My fork added in `full_load` and the error was removed. Hope this helps!